### PR TITLE
Update layout upon change in columns length

### DIFF
--- a/addon/components/ember-table-legacy.js
+++ b/addon/components/ember-table-legacy.js
@@ -382,11 +382,11 @@ StyleBindingsMixin, ResizeHandlerMixin, {
     }
   },
 
-  onBodyContentLengthDidChange: Ember.observer(function() {
+  onContentLengthDidChange: Ember.observer(function() {
     Ember.run.next(this, function() {
       Ember.run.once(this, this.updateLayout);
     });
-  }, 'bodyContent.length'),
+  }, 'bodyContent.length', 'columns.length'),
 
   // ---------------------------------------------------------------------------
   // Private variables


### PR DESCRIPTION
The `editable-table` component in Iverson is built on top of `ember-table-legacy` and supports inserting columns. [ADPR-38008](https://addepar.atlassian.net/browse/ADPR-38008) describes a bug where the horizontal scrollbar does not reliably appear when there are many columns. This occurred because the layout is updated only when the number of rows changes. Now it updates whenever the number of columns changes as well.