### PR TITLE
Use `getViewById` util function instead of Ember.View.views

### DIFF
--- a/addon/components/ember-table-legacy.js
+++ b/addon/components/ember-table-legacy.js
@@ -3,6 +3,7 @@ import StyleBindingsMixin from 'ember-table-legacy/mixins/style-bindings';
 import ResizeHandlerMixin from 'ember-table-legacy/mixins/resize-handler';
 import RowArrayController from 'ember-table-legacy/controllers/row-array';
 import Row from 'ember-table-legacy/controllers/row';
+import getViewById from 'ember-table-legacy/utils/get-view-by-id';
 
 export default Ember.Component.extend(
 StyleBindingsMixin, ResizeHandlerMixin, {
@@ -631,7 +632,7 @@ StyleBindingsMixin, ResizeHandlerMixin, {
 
   getRowForEvent: function(event) {
     var $rowView = Ember.$(event.target).parents('.ember-table-table-row');
-    var view = Ember.View.views[$rowView.attr('id')];
+    var view = getViewById(this, $rowView.attr('id'));
     if (view) {
       return view.get('row');
     }

--- a/addon/utils/get-view-by-id.js
+++ b/addon/utils/get-view-by-id.js
@@ -1,0 +1,4 @@
+export default function getViewById(context, viewId) {
+  let viewRegistry = context.get('_viewRegistry');
+  return viewRegistry[viewId];
+}

--- a/addon/views/header-row.js
+++ b/addon/views/header-row.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import StyleBindingsMixin from 'ember-table-legacy/mixins/style-bindings';
 import RegisterTableComponentMixin from 'ember-table-legacy/mixins/register-table-component';
+import getViewById from 'ember-table-legacy/utils/get-view-by-id';
 
 // We hacked this. There is an inconsistency at the level in which we are
 // handling scroll event...
@@ -62,7 +63,7 @@ StyleBindingsMixin, RegisterTableComponentMixin, {
   onColumnSortDone: function(event, ui) {
     var newIndex = ui.item.index();
     this.$('> div').sortable('cancel');
-    var view = Ember.View.views[ui.item.attr('id')];
+    var view = getViewById(this, ui.item.attr('id'));
     var column = view.get('column');
     this.get('tableComponent').onColumnSort(column, newIndex);
     this.set('tableComponent._isShowingSortableIndicator', false);


### PR DESCRIPTION
Versions of Ember after 1.12 don't provide a global registry at
`Ember.View.views`. This extracts that pattern into a util function `getViewById`
that works with both 1.12 and Ember 1.13.